### PR TITLE
remove ".llseek = no_llseek" from gasket_core.c

### DIFF
--- a/src/gasket_core.c
+++ b/src/gasket_core.c
@@ -1373,7 +1373,6 @@ static long gasket_ioctl(struct file *filp, uint cmd, ulong arg)
 /* File operations for all Gasket devices. */
 static const struct file_operations gasket_file_ops = {
 	.owner = THIS_MODULE,
-	.llseek = no_llseek,
 	.mmap = gasket_mmap,
 	.open = gasket_open,
 	.release = gasket_release,

--- a/src/gasket_core.c
+++ b/src/gasket_core.c
@@ -1374,6 +1374,9 @@ static long gasket_ioctl(struct file *filp, uint cmd, ulong arg)
 static const struct file_operations gasket_file_ops = {
 	.owner = THIS_MODULE,
 	.mmap = gasket_mmap,
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
+	.llseek = no_llseek,
+	#endif
 	.open = gasket_open,
 	.release = gasket_release,
 	.unlocked_ioctl = gasket_ioctl,


### PR DESCRIPTION
kernel 6.12 removes support for no_llseek.   DKMS fails to install when no_llseek is present.