### PR TITLE
Fixes for RHEL9 kernel backports

### DIFF
--- a/src/gasket_core.c
+++ b/src/gasket_core.c
@@ -1840,12 +1840,14 @@ int gasket_register_device(const struct gasket_driver_desc *driver_desc)
 	memset(internal->devs, 0, sizeof(struct gasket_dev *) * GASKET_DEV_MAX);
 
     /* Function signature for `class_create()` is changed in kernel >= 6.4.x
-     * to only accept a single argument.
+     * to only accept a single argument. This change was also backported to
+     * RHEL 9.4, whose kernel is nominally versioned 5.14.0.
      * */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-    internal->class = class_create(driver_desc->module, driver_desc->name);
-#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || \
+    (defined RHEL_RELEASE_CODE && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
     internal->class = class_create(driver_desc->name);
+#else
+    internal->class = class_create(driver_desc->module, driver_desc->name);
 #endif
 
 	if (IS_ERR(internal->class)) {

--- a/src/gasket_interrupt.c
+++ b/src/gasket_interrupt.c
@@ -158,7 +158,8 @@ gasket_handle_interrupt(struct gasket_interrupt_data *interrupt_data,
 	read_lock(&interrupt_data->eventfd_ctx_lock);
 	ctx = interrupt_data->eventfd_ctxs[interrupt_index];
         if (ctx)
-                #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
+                #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0) || \
+                (defined RHEL_RELEASE_CODE && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))
                         eventfd_signal(ctx);
                 #else
                         eventfd_signal(ctx, 1);


### PR DESCRIPTION
Closes #7; closes #13.

RHEL's kernels have backported changes from newer versions, so additional conditional compilation checks using RHEL-specific macros are necessary.

I originally submitted them to upstream at google/gasket-driver#29 and google/gasket-driver#37. But on [recommendation from  a SUSE maintainer](https://github.com/google/gasket-driver/pull/37#issuecomment-2565530579), I think it's a better idea to add those distro-specific patches here.