### PR TITLE
DMA_BUFF NS support for Kernel 6.13+

### DIFF
--- a/src/gasket_page_table.c
+++ b/src/gasket_page_table.c
@@ -54,7 +54,11 @@
 #include <linux/vmalloc.h>
 
 #if __has_include(<linux/dma-buf.h>)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+MODULE_IMPORT_NS("DMA_BUF");
+#else
 MODULE_IMPORT_NS(DMA_BUF);
+#endif
 #endif
 
 #include "gasket_constants.h"


### PR DESCRIPTION
This commit assumes the merging of #14 first.

in order to build on kernel 6.13+ you need both #14 and this PR.

This commit applies the same fix as for nvidia-utils: https://gitlab.archlinux.org/archlinux/packaging/packages/nvidia-utils/-/commit/101b429bbf1ff62947f50a7e983d0086db8f2df9

Tested and verified on 6.13.7-100.fc40.x86_64